### PR TITLE
Drop unneeded dependencies & ensure OpenMP dependencies are consistent

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -177,8 +177,6 @@ outputs:
         - r-magrittr
         - r-jsonlite
         - r-knitr
-        - cudatoolkit      # [(cuda_compiler_version or "").startswith("11")]
-        - cuda-cudart-dev  # [(cuda_compiler_version or "").startswith("12")]
       run:
         - {{ pin_subpackage('libxgboost', exact=True) }}
         - {{ pin_subpackage('_r-xgboost-mutex', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,8 +36,6 @@ requirements:
     - cudatoolkit      # [(cuda_compiler_version or "").startswith("11")]
     - cuda-cudart-dev  # [(cuda_compiler_version or "").startswith("12")]
     - nccl             # [linux and cuda_compiler != "None"]
-    - llvm-openmp  # [osx]
-    - libgomp      # [linux]
     - librmm ={{ rapids_version }}  # [linux and cuda_compiler != "None"]
 
 outputs:
@@ -59,8 +57,6 @@ outputs:
         - llvm-openmp  # [osx]
         - libgomp      # [linux]
       host:
-        - llvm-openmp  # [osx]
-        - libgomp      # [linux]
         - cudatoolkit      # [(cuda_compiler_version or "").startswith("11")]
         - cuda-cudart-dev  # [(cuda_compiler_version or "").startswith("12")]
         - nccl             # [linux and cuda_compiler != "None"]
@@ -176,8 +172,6 @@ outputs:
       host:
         - {{ pin_subpackage('libxgboost', exact=True) }}
         - r-base
-        - llvm-openmp  # [osx]
-        - libgomp      # [linux]
         - r-matrix
         - r-data.table
         - r-magrittr

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -131,11 +131,6 @@ outputs:
     requirements:
       host:
         - python
-        # we install llvm-opnemp here to convince conda to
-        # install llvm-openmp in the top-level host env above
-        - llvm-openmp  # [osx]
-        - cudatoolkit      # [(cuda_compiler_version or "").startswith("11")]
-        - cuda-cudart-dev  # [(cuda_compiler_version or "").startswith("12")]
       run:
         - python
         - {{ pin_subpackage('py-xgboost', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,12 +30,14 @@ requirements:
     - m2-git                 # [win]
     - cmake
     - llvm-openmp  # [osx]
+    - libgomp      # [linux]
     - ninja
   host:
     - cudatoolkit      # [(cuda_compiler_version or "").startswith("11")]
     - cuda-cudart-dev  # [(cuda_compiler_version or "").startswith("12")]
     - nccl             # [linux and cuda_compiler != "None"]
     - llvm-openmp  # [osx]
+    - libgomp      # [linux]
     - librmm ={{ rapids_version }}  # [linux and cuda_compiler != "None"]
 
 outputs:
@@ -55,14 +57,17 @@ outputs:
         - cmake
         - make
         - llvm-openmp  # [osx]
+        - libgomp      # [linux]
       host:
         - llvm-openmp  # [osx]
+        - libgomp      # [linux]
         - cudatoolkit      # [(cuda_compiler_version or "").startswith("11")]
         - cuda-cudart-dev  # [(cuda_compiler_version or "").startswith("12")]
         - nccl             # [linux and cuda_compiler != "None"]
         - librmm ={{ rapids_version }}  # [linux and cuda_compiler != "None"]
       run:
         - llvm-openmp  # [osx]
+        - libgomp      # [linux]
         - librmm ={{ rapids_version }}  # [linux and cuda_compiler != "None"]
         - __cuda  # [cuda_compiler != "None"]
 
@@ -157,6 +162,7 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - llvm-openmp            # [osx]
+        - libgomp                # [linux]
         - git
         - make                   # [not win]
         - posix                  # [win]
@@ -173,6 +179,7 @@ outputs:
         - {{ pin_subpackage('libxgboost', exact=True) }}
         - r-base
         - llvm-openmp  # [osx]
+        - libgomp      # [linux]
         - r-matrix
         - r-data.table
         - r-magrittr
@@ -184,6 +191,7 @@ outputs:
         - {{ pin_subpackage('libxgboost', exact=True) }}
         - {{ pin_subpackage('_r-xgboost-mutex', exact=True) }}
         - llvm-openmp  # [osx]
+        - libgomp      # [linux]
         - r-base
         - r-matrix
         - r-data.table

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -156,7 +156,6 @@ outputs:
         - {{ compiler('m2w64_cxx') }}        # [win]
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
-        - {{ compiler('cuda') }}                 # [cuda_compiler != "None"]
         - llvm-openmp            # [osx]
         - git
         - make                   # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,8 +66,6 @@ outputs:
         - nccl             # [linux and cuda_compiler != "None"]
         - librmm ={{ rapids_version }}  # [linux and cuda_compiler != "None"]
       run:
-        - llvm-openmp  # [osx]
-        - libgomp      # [linux]
         - librmm ={{ rapids_version }}  # [linux and cuda_compiler != "None"]
         - __cuda  # [cuda_compiler != "None"]
 
@@ -190,8 +188,6 @@ outputs:
       run:
         - {{ pin_subpackage('libxgboost', exact=True) }}
         - {{ pin_subpackage('_r-xgboost-mutex', exact=True) }}
-        - llvm-openmp  # [osx]
-        - libgomp      # [linux]
         - r-base
         - r-matrix
         - r-data.table


### PR DESCRIPTION
The `xgboost` & `r-xgboost` packages are installing CUDA dependencies that they don't need. Also `xgboost` is installing OpenMP, which it doesn't need as it is a metapackage, which will pick this up from dependencies. Simply drop these to resolve this issue.

Also when OpenMP is used as a dependency, make sure it is added consistently for macOS & Linux.