### PR TITLE
Slightly relax `libxgboost` pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,12 +80,14 @@ outputs:
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
       host:
-        - {{ pin_subpackage('libxgboost', exact=True) }}
+        - {{ pin_subpackage('libxgboost', max_pin="x.x.x.x.x.x") }}
+        - libxgboost =*=rapidsai_h*_{{ PKG_BUILDNUM }}
         - python
         - setuptools
         - pip
       run:
-        - {{ pin_subpackage('libxgboost', exact=True) }}
+        - {{ pin_subpackage('libxgboost', max_pin="x.x.x.x.x.x") }}
+        - libxgboost =*=rapidsai_h*_{{ PKG_BUILDNUM }}
         - python
         - numpy
         - scipy
@@ -103,7 +105,8 @@ outputs:
         - python
       run:
         - python
-        - {{ pin_subpackage('py-xgboost', exact=True) }}
+        - {{ pin_subpackage('py-xgboost', max_pin="x.x.x.x.x.x") }}
+        - py-xgboost =*=rapidsai_py{{ CONDA_PY }}h*_{{ PKG_BUILDNUM }}
 
   - name: r-xgboost
     script: install-r-xgboost.sh  # [not win]
@@ -133,7 +136,8 @@ outputs:
         - r-jsonlite                 # [build_platform != target_platform]
         - r-knitr                    # [build_platform != target_platform]
       host:
-        - {{ pin_subpackage('libxgboost', exact=True) }}
+        - {{ pin_subpackage('libxgboost', max_pin="x.x.x.x.x.x") }}
+        - libxgboost =*=rapidsai_h*_{{ PKG_BUILDNUM }}
         - r-base
         - r-matrix
         - r-data.table
@@ -141,7 +145,8 @@ outputs:
         - r-jsonlite
         - r-knitr
       run:
-        - {{ pin_subpackage('libxgboost', exact=True) }}
+        - {{ pin_subpackage('libxgboost', max_pin="x.x.x.x.x.x") }}
+        - libxgboost =*=rapidsai_h*_{{ PKG_BUILDNUM }}
         - r-base
         - r-matrix
         - r-data.table

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "xgboost" %}
 {% set version = "1.7.4" %}
-{% set build_number = "2" %}
+{% set build_number = "3" %}
 {% set rapids_version = "23.08" %}
 
 package:


### PR DESCRIPTION
Pinning to exact package hash is too stringent as there are now CPU & CUDA builds of `libxgboost` that are used interchangeably by downstream XGBoost packages. So drop the package hash constraint, but match the rest of the version and build string as much as possible. This should fix some install issues we have seen due to the exact constraint that was here before.