### PR TITLE
Turn off verbose mode with CMake

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,5 +21,5 @@ cmake ${CMAKE_ARGS} \
       -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON \
       -DCMAKE_INSTALL_PREFIX:PATH="${PREFIX}" \
       "${SRC_DIR}"
-cmake --build . --config Release -- -v
+cmake --build . --config Release
 popd


### PR DESCRIPTION
As part of debugging, verbose mode was turned on with CMake. As it is no longer needed, turn it back off.