### PR TITLE
Minor cleanup of the recipe

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,5 @@
+azure:
+  free_disk_space: true
 build_platform:
   linux_aarch64: linux_64
   osx_arm64: osx_64
@@ -18,5 +20,3 @@ provider:
   osx: github_actions
   win: github_actions
 test_on_native_only: true
-azure:
-  free_disk_space: true

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,5 +21,5 @@ cmake ${CMAKE_ARGS} \
       -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON \
       -DCMAKE_INSTALL_PREFIX:PATH="${PREFIX}" \
       "${SRC_DIR}"
-cmake --build . --config Release -- -v
+cmake --build . --config Release
 popd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,6 @@ requirements:
     - libgomp      # [linux]
     - ninja
   host:
-    - cudatoolkit      # [(cuda_compiler_version or "").startswith("11")]
     - nccl             # [linux and cuda_compiler != "None"]
     - librmm ={{ rapids_version }}  # [linux and cuda_compiler != "None"]
 
@@ -59,7 +58,6 @@ outputs:
         - llvm-openmp  # [osx]
         - libgomp      # [linux]
       host:
-        - cudatoolkit      # [(cuda_compiler_version or "").startswith("11")]
         - nccl             # [linux and cuda_compiler != "None"]
         - librmm ={{ rapids_version }}  # [linux and cuda_compiler != "None"]
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,6 @@ requirements:
     - ninja
   host:
     - cudatoolkit      # [(cuda_compiler_version or "").startswith("11")]
-    - cuda-cudart-dev  # [(cuda_compiler_version or "").startswith("12")]
     - nccl             # [linux and cuda_compiler != "None"]
     - librmm ={{ rapids_version }}  # [linux and cuda_compiler != "None"]
 
@@ -49,7 +48,6 @@ outputs:
       string: rapidsai_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
       ignore_run_exports_from:
         - {{ compiler('cuda') }}  # [(cuda_compiler_version or "").startswith("11")]
-        - cuda-cudart-dev  # [(cuda_compiler_version or "").startswith("12")]
     requirements:
       build:
         - {{ compiler('c') }}
@@ -62,7 +60,6 @@ outputs:
         - libgomp      # [linux]
       host:
         - cudatoolkit      # [(cuda_compiler_version or "").startswith("11")]
-        - cuda-cudart-dev  # [(cuda_compiler_version or "").startswith("12")]
         - nccl             # [linux and cuda_compiler != "None"]
         - librmm ={{ rapids_version }}  # [linux and cuda_compiler != "None"]
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,15 +27,15 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - {{ compiler('cuda') }}                 # [cuda_compiler != "None"]
-    - git                    # [not win]
-    - m2-git                 # [win]
+    - {{ compiler('cuda') }}  # [cuda_compiler != "None"]
+    - git                     # [not win]
+    - m2-git                  # [win]
     - cmake
     - llvm-openmp  # [osx]
     - libgomp      # [linux]
     - ninja
   host:
-    - nccl             # [linux and cuda_compiler != "None"]
+    - nccl                          # [linux and cuda_compiler != "None"]
     - librmm ={{ rapids_version }}  # [linux and cuda_compiler != "None"]
 
 outputs:
@@ -51,19 +51,19 @@ outputs:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
-        - {{ compiler('cuda') }}                 # [cuda_compiler != "None"]
+        - {{ compiler('cuda') }}  # [cuda_compiler != "None"]
         - git
         - cmake
         - make
         - llvm-openmp  # [osx]
         - libgomp      # [linux]
       host:
-        - nccl             # [linux and cuda_compiler != "None"]
+        - nccl                          # [linux and cuda_compiler != "None"]
         - librmm ={{ rapids_version }}  # [linux and cuda_compiler != "None"]
       run:
         - cuda-version >=11.2,<12  # [(cuda_compiler_version or "").startswith("11")]
       run_constrained:
-        - librmm ={{ rapids_version }}               # [linux and cuda_compiler != "None"]
+        - librmm ={{ rapids_version }}  # [linux and cuda_compiler != "None"]
 
   - name: py-xgboost
     script: install-py-xgboost.sh  # [not win]
@@ -116,8 +116,8 @@ outputs:
         - {{ compiler('m2w64_cxx') }}  # [win]
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
-        - llvm-openmp            # [osx]
-        - libgomp                # [linux]
+        - llvm-openmp                  # [osx]
+        - libgomp                      # [linux]
         - git
         - make                         # [not win]
         - posix                        # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "xgboost" %}
 {% set version = "1.7.4" %}
-{% set build_number = "5" %}
+{% set build_number = "6" %}
 {% set rapids_version = "23.08" %}
 
 package:


### PR DESCRIPTION
* Turn off verbose CMake builds (leftover from previous debugging)
* Drop unneeded `cuda-cudart-dev` (now statically linked and pulled in by `{{ compiler('cuda') }}`)
* Also drop unneeded `cudatoolkit` dependency (already pulled in by `{{ compiler('cuda') }}`)
* Sort `conda-forge.yml` keys
* Fix selector indentation