### PR TITLE
Update rapids_version to 23.10

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "xgboost" %}
 {% set version = "1.7.6" %}
 {% set build_number = "0" %}
-{% set rapids_version = "23.08" %}
+{% set rapids_version = "23.10" %}
 
 package:
   name: xgboost-split


### PR DESCRIPTION
Just updates the `rapids_version` to `23.10` so we can build `integration` and `docker` downstream.
