### PR TITLE
Use GIT_DESCRIBE_NUMBER instead of hard coded value

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "xgboost" %}
 {% set version = "1.7.6" %}
-{% set build_number = "0" %}
 {% set rapids_version = "23.10" %}
 
 package:
@@ -19,7 +18,7 @@ source:
     - 0002-Use-static-cudart.patch
 
 build:
-  number: {{ build_number }}
+  number: {{ GIT_DESCRIBE_NUMBER }}
   skip: true  # [win and cuda_compiler != "None"]
   skip: true  # [linux and cuda_compiler == "None"]
 


### PR DESCRIPTION
It looks like despite updating the `librmm`[ version](https://github.com/rapidsai/xgboost-feedstock/pull/25) in the recipe, the `PKG_HASH` did not change. Looks like it [doesn't include](https://github.com/rapidsai/xgboost-feedstock/actions/runs/5858796331/job/15883457994#step:4:4919) `librmm` in the hash, so the new packages were [not uploaded](https://github.com/rapidsai/xgboost-feedstock/actions/runs/5858796331/job/15883457994#step:4:5033).

So adding `GIT_DESCRIBE_NUMBER` as the `build.number` will always result in a unique build on the `main` branch preventing this problem.
