### PR TITLE
Force the hash to include `librmm`

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,6 @@
+librmm:
+  - 23.10
+
 channel_sources:
   - rapidsai,rapidsai-nightly,conda-forge
 channel_targets:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "xgboost" %}
 {% set version = "1.7.6" %}
 {% set build_number = "0" %}
-{% set rapids_version = "23.10" %}
 
 package:
   name: xgboost-split
@@ -35,8 +34,8 @@ requirements:
     - libgomp      # [linux]
     - ninja
   host:
-    - nccl                          # [linux and cuda_compiler != "None"]
-    - librmm ={{ rapids_version }}  # [linux and cuda_compiler != "None"]
+    - nccl         # [linux and cuda_compiler != "None"]
+    - librmm       # [linux and cuda_compiler != "None"]
 
 outputs:
   - name: libxgboost
@@ -45,8 +44,6 @@ outputs:
     build:
       activate_in_script: True
       string: rapidsai_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
-      force_use_keys:
-        - librmm  # [linux and cuda_compiler != "None"]
       ignore_run_exports_from:
         - {{ compiler('cuda') }}  # [(cuda_compiler_version or "").startswith("11")]
     requirements:
@@ -60,12 +57,12 @@ outputs:
         - llvm-openmp  # [osx]
         - libgomp      # [linux]
       host:
-        - nccl                          # [linux and cuda_compiler != "None"]
-        - librmm ={{ rapids_version }}  # [linux and cuda_compiler != "None"]
+        - nccl         # [linux and cuda_compiler != "None"]
+        - librmm       # [linux and cuda_compiler != "None"]
       run:
         - cuda-version >=11.2,<12  # [(cuda_compiler_version or "").startswith("11")]
       run_constrained:
-        - librmm ={{ rapids_version }}  # [linux and cuda_compiler != "None"]
+        - {{ pin_compatible('librmm', max_pin='x.x.x') }}  # [linux and cuda_compiler != "None"]
 
   - name: py-xgboost
     script: install-py-xgboost.sh  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,8 @@ outputs:
     build:
       activate_in_script: True
       string: rapidsai_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
+      force_use_keys:
+        - librmm  # [linux and cuda_compiler != "None"]
       ignore_run_exports_from:
         - {{ compiler('cuda') }}  # [(cuda_compiler_version or "").startswith("11")]
     requirements:


### PR DESCRIPTION
When inspecting recent `libxgboost` packages to find whether `librmm` was used to construct the hash, found the following results. Note that `nccl` is present, but `librmm` is missing.

<details>

```bash
$ conda inspect hash-inputs libxgboost-1.7.6-cuda112h1c52686_0.conda 
{'libxgboost-1.7.6-cuda112h1c52686': {'recipe': {'__cuda': '__cuda',
                                                 'c_compiler': 'gcc',
                                                 'c_compiler_version': '10',
                                                 'channel_targets': 'conda-forge '
                                                                    'main',
                                                 'cuda_compiler': 'nvcc',
                                                 'cuda_compiler_version': '11.2',
                                                 'cxx_compiler': 'gxx',
                                                 'cxx_compiler_version': '10',
                                                 'nccl': '2',
                                                 'target_platform': 'linux-aarch64'}}}
```

</details>

~~While there are several ways to affect what is used in the package hash, this PR picks [`force_use_keys`]( https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html?highlight=force_use_keys#build-number-and-string ) to ensure `librmm` is always included in the package hash.~~ This didn't work as [the `librmm` key was not found]( https://github.com/rapidsai/xgboost-feedstock/actions/runs/5905884342/job/16020816237?pr=27#step:4:708 )

Have added `librmm` to `conda_build_config.yaml`, which also should be used for hash inclusion. If that doesn't work, can try adding to `force_use_keys` with this change

cc @raydouglass