### PR TITLE
Update RAPIDS version to 23.12

### DIFF
--- a/.ci_support/linux_64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10.yaml
+++ b/.ci_support/linux_64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.2
 librmm:
-- '23.10'
+- '23.12'
 nccl:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
+++ b/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 librmm:
-- '23.10'
+- '23.12'
 nccl:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version10cuda_compilernvcccuda_compiler_version11.2cxx_compiler_version10.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.2
 librmm:
-- '23.10'
+- '23.12'
 nccl:
 - '2'
 pin_run_as_build:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,5 @@
 librmm:
-  - 23.10
+  - 23.12
 
 channel_sources:
   - rapidsai,rapidsai-nightly,conda-forge


### PR DESCRIPTION
Just updating the RAPIDS version to `23.12` now that we're in burndown for `23.10`.

Assuming no other PRs merge before this one, `23.10` will be tagged to 092f52be7a38ce0ef2571cce52ff29d62f1e95e2 for release