### PR TITLE
Ensure `librmm` is included in all XGBoost packages' hashes

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,7 @@ outputs:
       string: rapidsai_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
       ignore_run_exports_from:
         - {{ compiler('cuda') }}  # [(cuda_compiler_version or "").startswith("11")]
+        - librmm                  # [linux and cuda_compiler != "None"]
     requirements:
       build:
         - {{ compiler('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,6 +74,8 @@ outputs:
     script: install-win-wrapper.bat  # [win]
     build:
       string: rapidsai_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
+      force_use_keys:
+        - librmm                  # [linux and cuda_compiler != "None"]
     requirements:
       build:
         - python                                 # [build_platform != target_platform]
@@ -99,6 +101,8 @@ outputs:
   - name: xgboost
     build:
       string: rapidsai_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
+      force_use_keys:
+        - librmm                  # [linux and cuda_compiler != "None"]
     requirements:
       host:
         - python
@@ -114,6 +118,8 @@ outputs:
       string: rapidsai_r{{ r_base | replace('.', '') }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
       rpaths:
         - lib/R/lib
+      force_use_keys:
+        - librmm                  # [linux and cuda_compiler != "None"]
     requirements:
       build:
         - {{ compiler('m2w64_c') }}    # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "xgboost" %}
 {% set version = "1.7.6" %}
-{% set build_number = 6 %}
+{% set build_number = 7 %}
 
 package:
   name: xgboost-split


### PR DESCRIPTION
Previously `librmm` was only considered in `libxgboost`'s package hash. However as `librmm` contains RAPIDS version information that we would like filtered through the other XGBoost packages, include `librmm` in `force_use_keys` to ensure it is always considered when generating package hashes.