### PR TITLE
Relax `librmm` pin to `<major>.<minor>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About xgboost-feedstock
 =======================
 
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/xgboost-feedstock-2-feedstock/blob/main/LICENSE.txt)
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/xgboost-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/dmlc/xgboost
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "xgboost" %}
 {% set version = "1.7.6" %}
-{% set build_number = 7 %}
+{% set build_number = 8 %}
 
 package:
   name: xgboost-split

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,7 +67,7 @@ outputs:
         - cuda-version >={{ 11.2 }},<12
         {% endif %}
       run_constrained:
-        - {{ pin_compatible('librmm', max_pin='x.x.x') }}  # [linux and cuda_compiler != "None"]
+        - {{ pin_compatible('librmm', max_pin='x.x') }}  # [linux and cuda_compiler != "None"]
 
   - name: py-xgboost
     script: install-py-xgboost.sh  # [not win]


### PR DESCRIPTION
Soften the `librmm` pinning to allow new patch versions without rebuilding `libxgboost`.