### PR TITLE
Add GHA workflow stub for uploading packages

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,6 +1,4 @@
 name: Upload conda packages
-on:
-  push
 
 jobs:
   on-success:

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,0 +1,16 @@
+name: Upload conda packages
+
+jobs:
+  on-success:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Build passing"
+          exit 0
+
+  on-failure:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Build failing"
+          exit 1

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,4 +1,6 @@
 name: Upload conda packages
+on:
+  push
 
 jobs:
   on-success:

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,8 +1,15 @@
 name: Upload conda packages
+on:
+  workflow_run:
+    workflows:
+      - Build conda package
+    types:
+      - completed
 
 jobs:
   on-success:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == "success" }}
     steps:
       - run: |
           echo "Build passing"
@@ -10,6 +17,7 @@ jobs:
 
   on-failure:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == "failure" }}
     steps:
       - run: |
           echo "Build failing"


### PR DESCRIPTION
We would like to use the `workflow_run` event to add a custom conda package upload workflow after packages are built. However in the GitHub Actions (GHA) docs, it states that `workflow_run` events will only be triggered if the workflow is on the default branch. Though we have not figured out completely how to implement this workflow and don't want to add it untested to `main`. So simply add a stub workflow with the `workflow_run` event. This way GHA will run the workflow, but we can start customizing it in a PR instead where we can actually test its behavior.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run