### PR TITLE
Use single quotes in GHA workflow check

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   on-success:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == "success" }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - run: |
           echo "Build passing"
@@ -17,7 +17,7 @@ jobs:
 
   on-failure:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == "failure" }}
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:
       - run: |
           echo "Build failing"


### PR DESCRIPTION
Seeing [a GHA error]( https://github.com/rapidsai/xgboost-feedstock/actions/runs/8745328314/workflow ) in this check:

https://github.com/rapidsai/xgboost-feedstock/blob/9c5cb3c0155e758d93b2506f37053d8b1a937271/.github/workflows/upload.yml#L12

Looks like the string needs to be single quoted. So make that change
