### PR TITLE
Enable all `branches` on upload workflow

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -3,6 +3,8 @@ on:
   workflow_run:
     workflows:
       - Build conda package
+    branches:
+      - '**'
     types:
       - completed
 


### PR DESCRIPTION
Make sure all branches on the repo run the upload workflow.