### PR TITLE
Add missing `noarch: python` to `xgboost` package

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -130,6 +130,7 @@ outputs:
 
   - name: xgboost
     build:
+      noarch: python
       string: {{ string_prefix }}_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
       force_use_keys:
         - librmm                  # [linux and cuda_compiler != "None"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "xgboost" %}
 {% set version = "2.1.1" %}
-{% set build_number = 2 %}
+{% set build_number = 3 %}
 {% set min_python = "3.8" %}
 
 {% set string_prefix = "rapidsai" %}


### PR DESCRIPTION
The `xgboost` package is marked `noarch: python` as it is a pure Python package. This was accidentally dropped when upstreaming.