### PR TITLE
Rebuild 24.08 with (`noarch: python` fix for `xgboost`)

### DIFF
--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11python3.8.____cpython.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.8
 librmm:
-- '24.10'
+- '24.08'
 nccl:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12python3.8.____cpython.yaml
@@ -23,7 +23,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 librmm:
-- '24.10'
+- '24.08'
 nccl:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11python3.8.____cpython.yaml
@@ -27,7 +27,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.8
 librmm:
-- '24.10'
+- '24.08'
 nccl:
 - '2'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12python3.8.____cpython.yaml
@@ -27,7 +27,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 librmm:
-- '24.10'
+- '24.08'
 nccl:
 - '2'
 pin_run_as_build:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,5 @@
 librmm:
-  - 24.10
+  - 24.08
 
 channel_sources:
   - rapidsai,rapidsai-nightly,conda-forge

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "xgboost" %}
 {% set version = "2.1.1" %}
-{% set build_number = 3 %}
+{% set build_number = 4 %}
 {% set min_python = "3.8" %}
 
 {% set string_prefix = "rapidsai" %}


### PR DESCRIPTION
Recently we caught and fixed a bug in the XGBoost packages where they were missing a `noarch: python`. As a result the `xgboost` packages were only built for installation on Python 3.12. Unfortunately this doesn't line up with RAPIDS (especially as we don't have Python 3.12 yet). So this was fixed in PR: https://github.com/rapidsai/xgboost-feedstock/pull/69

While this is fixed in 24.10, unfortunately the 24.08 packages of XGBoost are still broken. To fix this, we temporarily go back to 24.08 in this XGBoost PR. This will fill in the missing packages for 24.08

Once this is built out, we can switch back to 24.10
