### PR TITLE
Use GLIBC 2.28 & Merge `conda-forge/main` into `rapidsai/main` (pt. 22)

### DIFF
--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.28'
 cdt_name:
 - conda
 channel_sources:

--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
@@ -21,7 +21,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '11'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64-cuda11.8:cos7
+- quay.io/condaforge/linux-anvil-x86_64-cuda11.8:ubi8
 librmm:
 - '25.04'
 nccl:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.8cxx_compiler_version13.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.8cxx_compiler_version13.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.28'
 cdt_name:
 - conda
 channel_sources:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.8cxx_compiler_version13.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.8cxx_compiler_version13.yaml
@@ -21,7 +21,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:cos7
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 librmm:
 - '25.04'
 nccl:

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.28'
 cdt_name:
 - conda
 channel_sources:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.8cxx_compiler_version13.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.8cxx_compiler_version13.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.28'
 cdt_name:
 - conda
 channel_sources:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.8cxx_compiler_version13.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.8cxx_compiler_version13.yaml
@@ -21,7 +21,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:cos7
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 librmm:
 - '25.04'
 nccl:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -27,12 +27,12 @@ jobs:
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64-cuda11.8:cos7
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64-cuda11.8:ubi8
           - CONFIG: linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.8cxx_compiler_version13
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11
             UPLOAD_PACKAGES: True
             os: ubuntu
@@ -42,7 +42,7 @@ jobs:
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: osx_64_
             UPLOAD_PACKAGES: True
             os: macos

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -15,10 +15,6 @@ github_actions:
   artifact_retention_days: 7
   free_disk_space: true
   upload_packages: true
-os_version:
-  linux_64: cos7
-  linux_aarch64: cos7
-  linux_ppc64le: cos7
 provider:
   linux: github_actions
   linux_aarch64: github_actions

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,5 @@
-librmm:
-  - 25.04
+librmm:            # [linux]
+  - 25.04          # [linux]
 
 channel_sources:
   - rapidsai,rapidsai-nightly,conda-forge

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,6 @@
+c_stdlib_version:  # [linux]
+  - 2.28           # [linux]
+
 librmm:            # [linux]
   - 25.04          # [linux]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "2.1.4" %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 
 {% set string_prefix = "rapidsai" %}
 
@@ -43,7 +43,12 @@ requirements:
     - libgomp      # [linux or win]
     - ninja
   host:
-    - cccl !=2.4.0,!=2.5.0  # [cuda_compiler != "None"]
+    ############################################################################################
+    # Pin to CCCL 2.7 to avoid build issues in older or newer CCCLs.                           #
+    #                                                                                          #
+    # xref: https://github.com/conda-forge/xgboost-feedstock/pull/219#issuecomment-2738813028  #
+    ############################################################################################
+    - cccl =2.7             # [cuda_compiler != "None"]
     - nccl                  # [linux and cuda_compiler != "None"]
     - librmm                # [linux and cuda_compiler != "None"]
 


### PR DESCRIPTION
Update builds to use GLIBC 2.28. This aligns XGBoost with the rest of RAPIDS, which already moved to GLIBC 2.28 ( https://github.com/rapidsai/build-planning/issues/131 ). Also aligns with the CUDA Toolkit, which [deprecated CentOS 7 (GLIBC 2.17) in CUDA 12.4]( https://docs.nvidia.com/cuda/archive/12.4.0/cuda-toolkit-release-notes/index.html#deprecated-operating-systems )

Also pulls in the upstream change to use the latest Linux OS when building packages: 

* https://github.com/conda-forge/xgboost-feedstock/pull/219

Collectively this should build RAPIDS XGBoost packages such that they are using the same GLIBC as RAPIDS as well as test packages on a modern OS (RHEL UBI 8 for CUDA 11 and AlmaLinux 9 for CUDA 12)