### PR TITLE
Drop obsolete CMake arg `BUILD_WITH_CUDA_CUB`

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,7 +14,7 @@ fi
 
 if [[ ${cuda_compiler_version} != "None" ]]; then
     XGB_CMAKE_ARGS=(-DUSE_CUDA=ON -DUSE_NCCL=ON -DBUILD_WITH_SHARED_NCCL=ON ${XGB_CMAKE_ARGS[@]+"${XGB_CMAKE_ARGS[@]}"} )
-    XGB_CMAKE_ARGS=(-DBUILD_WITH_CUDA_CUB=ON -DPLUGIN_RMM=ON ${XGB_CMAKE_ARGS[@]+"${XGB_CMAKE_ARGS[@]}"} )
+    XGB_CMAKE_ARGS=(-DPLUGIN_RMM=ON ${XGB_CMAKE_ARGS[@]+"${XGB_CMAKE_ARGS[@]}"} )
 fi
 
 # Limit number of threads used to avoid hardware oversubscription


### PR DESCRIPTION
The `BUILD_WITH_CUDA_CUB` was dropped with XGBoost 2. Setting it is giving warnings due to the fact that it is unused. So go ahead and drop it to clean this up.

Fixes https://github.com/rapidsai/xgboost-feedstock/issues/90