### PR TITLE
Rebuild for rmm CCCL upgrade

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.0.5" %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 {% set python_min = "3.10" %}
 {% set posix = 'm2-' if win else '' %}
 


### PR DESCRIPTION
https://github.com/rapidsai/rmm/pull/2017 was an ABI break that xgboost must be rebuilt to accommodate.