### PR TITLE
Use rapidsai-nightly channel as higher priority than rapidsai

### DIFF
--- a/.ci_support/linux_64_c_compiler_version14c_stdlib_version2.28cuda_compiler_version12.9cxx_compiler_version14.yaml
+++ b/.ci_support/linux_64_c_compiler_version14c_stdlib_version2.28cuda_compiler_version12.9cxx_compiler_version14.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - conda
 channel_sources:
-- rapidsai,rapidsai-nightly,conda-forge
+- rapidsai-nightly,rapidsai,conda-forge
 channel_targets:
 - rapidsai-nightly main
 cuda_compiler:

--- a/.ci_support/linux_64_c_compiler_version14c_stdlib_version2.28cuda_compiler_version13.0cxx_compiler_version14.yaml
+++ b/.ci_support/linux_64_c_compiler_version14c_stdlib_version2.28cuda_compiler_version13.0cxx_compiler_version14.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - conda
 channel_sources:
-- rapidsai,rapidsai-nightly,conda-forge
+- rapidsai-nightly,rapidsai,conda-forge
 channel_targets:
 - rapidsai-nightly main
 cuda_compiler:

--- a/.ci_support/linux_aarch64_c_compiler_version14c_stdlib_version2.28cuda_compiler_version12.9cxx_compiler_version14.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version14c_stdlib_version2.28cuda_compiler_version12.9cxx_compiler_version14.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - conda
 channel_sources:
-- rapidsai,rapidsai-nightly,conda-forge
+- rapidsai-nightly,rapidsai,conda-forge
 channel_targets:
 - rapidsai-nightly main
 cuda_compiler:

--- a/.ci_support/linux_aarch64_c_compiler_version14c_stdlib_version2.28cuda_compiler_version13.0cxx_compiler_version14.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version14c_stdlib_version2.28cuda_compiler_version13.0cxx_compiler_version14.yaml
@@ -9,7 +9,7 @@ c_stdlib_version:
 cdt_name:
 - conda
 channel_sources:
-- rapidsai,rapidsai-nightly,conda-forge
+- rapidsai-nightly,rapidsai,conda-forge
 channel_targets:
 - rapidsai-nightly main
 cuda_compiler:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '10.13'
 channel_sources:
-- rapidsai,rapidsai-nightly,conda-forge
+- rapidsai-nightly,rapidsai,conda-forge
 channel_targets:
 - rapidsai-nightly main
 cuda_compiler:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 channel_sources:
-- rapidsai,rapidsai-nightly,conda-forge
+- rapidsai-nightly,rapidsai,conda-forge
 channel_targets:
 - rapidsai-nightly main
 cuda_compiler:

--- a/.ci_support/win_64_cuda_compiler_version12.9.yaml
+++ b/.ci_support/win_64_cuda_compiler_version12.9.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- rapidsai,rapidsai-nightly,conda-forge
+- rapidsai-nightly,rapidsai,conda-forge
 channel_targets:
 - rapidsai-nightly main
 cuda_compiler:

--- a/.ci_support/win_64_cuda_compiler_version13.0.yaml
+++ b/.ci_support/win_64_cuda_compiler_version13.0.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_stdlib:
 - vs
 channel_sources:
-- rapidsai,rapidsai-nightly,conda-forge
+- rapidsai-nightly,rapidsai,conda-forge
 channel_targets:
 - rapidsai-nightly main
 cuda_compiler:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -85,7 +85,7 @@ jobs:
         df -h
 
     - name: Checkout code
-      uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
     - name: Build on Linux
       id: build-linux

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -3,7 +3,7 @@ azure:
 build_platform:
   linux_aarch64: linux_64
   osx_arm64: osx_64
-channel_priority: flexible
+channel_priority: strict
 conda_build:
   error_overlinking: true
   pkg_format: '2'

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,6 +2,6 @@ librmm:            # [linux]
   - 25.10          # [linux]
 
 channel_sources:
-  - rapidsai,rapidsai-nightly,conda-forge
+  - rapidsai-nightly,rapidsai,conda-forge
 channel_targets:
   - rapidsai-nightly main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.0.5" %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 {% set python_min = "3.10" %}
 {% set posix = 'm2-' if win else '' %}
 


### PR DESCRIPTION
Nightly packages (`rapidsai-nightly`) should take precedence over stable packages (`rapidsai`) if a suitable version can be found.
