### PR TITLE
Bump build number for new RMM build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ source:
     - patches/0002-Remove-nvidia-nccl-cu12-from-pyproject.toml.patch
     - patches/0003-Mark-wheels-as-any-platform-compatible.patch
     - patches/0004-Fix-compilation-with-the-latest-CCCL.patch
+    - patches/0005-Fix-missing-include.patch
 
 build:
   number: {{ build_number }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.2.0" %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 {% set python_min = "3.10" %}
 {% set posix = 'm2-' if win else '' %}
 

--- a/recipe/patches/0005-Fix-missing-include.patch
+++ b/recipe/patches/0005-Fix-missing-include.patch
@@ -1,0 +1,30 @@
+From 93ffb2a79899d451fadfaed21ea0cc44dd47b3f9 Mon Sep 17 00:00:00 2001
+From: Hyunsu Cho <phcho@nvidia.com>
+Date: Mon, 30 Mar 2026 21:19:30 -0700
+Subject: [PATCH] Fix missing include
+
+---
+ src/tree/gpu_hist/histogram.cu | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/src/tree/gpu_hist/histogram.cu b/src/tree/gpu_hist/histogram.cu
+index 55f4479d1..eefb9b0a3 100644
+--- a/src/tree/gpu_hist/histogram.cu
++++ b/src/tree/gpu_hist/histogram.cu
+@@ -5,9 +5,10 @@
+ #include <thrust/iterator/transform_iterator.h>  // for make_transform_iterator
+ 
+ #include <algorithm>
+-#include <cstdint>          // uint32_t, int32_t
+-#include <cuda/functional>  // for proclaim_copyable_arguments
+-#include <memory>           // for unique_ptr
++#include <cstdint>               // uint32_t, int32_t
++#include <cuda/functional>       // for proclaim_copyable_arguments
++#include <cuda/std/type_traits>  // for cuda::std::alignment_of_v
++#include <memory>                // for unique_ptr
+ 
+ #include "../../collective/aggregator.h"
+ #include "../../common/cuda_context.cuh"  // for CUDAContext
+-- 
+2.43.0
+


### PR DESCRIPTION
RMM 26.06 nightlies recently had an ABI break (https://github.com/rapidsai/rmm/pull/2330, https://github.com/rapidsai/rmm/pull/2337). This bumps the build number to rebuild against the latest RMM.
