### PR TITLE
Use `cuda_compiler_version` in `librmm` selectors

### DIFF
--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -14,8 +14,6 @@ channel_sources:
 - rapidsai-nightly,rapidsai,conda-forge
 channel_targets:
 - rapidsai-nightly main
-cuda_compiler:
-- cuda-nvcc
 cuda_compiler_version:
 - None
 cxx_compiler:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -14,8 +14,6 @@ channel_sources:
 - rapidsai-nightly,rapidsai,conda-forge
 channel_targets:
 - rapidsai-nightly main
-cuda_compiler:
-- cuda-nvcc
 cuda_compiler_version:
 - None
 cxx_compiler:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -103,7 +103,7 @@ outputs:
       noarch: python
       string: {{ string_prefix }}_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
       force_use_keys:
-        - librmm                  # [linux and cuda_compiler != "None"]
+        - librmm                  # [linux and cuda_compiler_version != "None"]
       script_env:
         # Workaround an upstream conda-build issue w/pip & `outputs` by setting env vars manually.
         # xref: https://github.com/conda/conda-build/issues/3993
@@ -145,7 +145,7 @@ outputs:
       noarch: python
       string: {{ string_prefix }}_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
       force_use_keys:
-        - librmm                  # [linux and cuda_compiler != "None"]
+        - librmm                  # [linux and cuda_compiler_version != "None"]
     requirements:
       host:
         - python {{ python_min }}
@@ -173,7 +173,7 @@ outputs:
       rpaths:
         - lib/R/lib
       force_use_keys:
-        - librmm                  # [linux and cuda_compiler != "None"]
+        - librmm                  # [linux and cuda_compiler_version != "None"]
     requirements:
       build:
         - {{ compiler('c') }}              # [unix]


### PR DESCRIPTION
As conda-forge always sets `cuda_compiler` to `cuda-nvcc` post-CUDA 11, it is never `None`. Given this checking `cuda_compiler` to `None` does not have the originally intended behavior of ignoring CUDA portions in CPU-only builds.

To fix this `cuda_compiler_version` is still set to `None` in the CPU-only case. So use that in checks instead.