### PR TITLE
Clarify RAPIDS requires Volta or newer  [ci skip]

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,7 +7,8 @@ set XGB_CMAKE_ARGS=""
 if not "%cuda_compiler_version%" == "None" (
     set "XGB_CMAKE_ARGS=-DUSE_CUDA:BOOL=ON"
     if "%cuda_compiler_version%" == "12.9" (
-        rem Disable sm_60 to work around NVIDIA/cccl#7982
+        rem RAPIDS requires Volta or newer.
+        rem ref: https://docs.rapids.ai/notices/rsn0034/
         set "CUDAARCHS=70;75;80;86;89;90;100;103;120;121"
     )
 )

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,7 +16,8 @@ then
 fi
 if [[ ${cuda_compiler_version} != "None" ]]; then
     if [[ ${cuda_compiler_version} == "12.9" ]]; then
-        # Disable sm_60 to work around NVIDIA/cccl#7982
+        # RAPIDS requires Volta or newer.
+        # ref: https://docs.rapids.ai/notices/rsn0034/
         export CUDAARCHS="70;75;80;86;89;90;100;103;120;121"
     fi
     XGB_CMAKE_ARGS=(


### PR DESCRIPTION
While it is true that CCCL had a bug that affects its ability to compile on Pascal. It is also true that RAPIDS dropped Pascal support in 24.02. So even with a CCCL release with a bug fix, it makes sense for RAPIDS to continue to exclude Pascal or earlier instructions when compiling XGBoost.

ref: https://docs.rapids.ai/notices/rsn0034/