### PR TITLE
Rebuild XGBoost with RMM 26.08 (pt. 2)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.3.0" %}
-{% set build_number = 2 %}
+{% set build_number = 3 %}
 {% set python_min = "3.12" %}
 {% set posix = 'm2-' if win else '' %}
 


### PR DESCRIPTION
Follow up to PR: https://github.com/rapidsai/xgboost-feedstock/pull/142

Rebuild with RMM 26.08 again to pick up the latest CCCL patches for XGBoost.

Refs:

* https://github.com/rapidsai/rapids-cmake/pull/1061
* https://github.com/rapidsai/rmm/pull/2490