### PR TITLE
Rebuild XGBoost with RMM 26.10 nightly

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.3.0" %}
-{% set build_number = 3 %}
+{% set build_number = 4 %}
 {% set python_min = "3.12" %}
 {% set posix = 'm2-' if win else '' %}
 


### PR DESCRIPTION
Pick up the latest RMM 26.10 nightly to pick up RMM fixes and recent CCCL patches.

Refs:

* https://github.com/rapidsai/rapids-cmake/pull/1061
* https://github.com/rapidsai/rmm/pull/2490