### PR TITLE
Enable builds & uploads on `release/26.08` branch

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -119,7 +119,7 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Manage disk space
       env:
@@ -155,7 +155,7 @@ jobs:
       run: |
         export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
-        export GIT_BRANCH="$(basename $GITHUB_REF)"
+        export GIT_BRANCH="${GITHUB_REF_NAME}"
         export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"
@@ -184,7 +184,7 @@ jobs:
       run: |
         export CONDA_BLD_PATH="${CONDA_BLD_PATH/#~/${HOME}}"
         export FEEDSTOCK_NAME="$(basename $GITHUB_REPOSITORY)"
-        export GIT_BRANCH="$(basename $GITHUB_REF)"
+        export GIT_BRANCH="${GITHUB_REF_NAME}"
         export MINIFORGE_HOME="${MINIFORGE_HOME/#~/${HOME}}"
         export flow_run_id="github_$GITHUB_RUN_ID"
         export remote_url="https://github.com/$GITHUB_REPOSITORY"

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -6,7 +6,7 @@ name: Build conda package
 on:
   push:
     branches:
-      - main
+      - release/26.08
 
   pull_request:
 
@@ -146,7 +146,7 @@ jobs:
         CONFIG: ${{ matrix.CONFIG }}
         MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
         DOCKER_IMAGE: ${{ matrix.DOCKER_IMAGE }}
-        UPLOAD_ON_BRANCH: main
+        UPLOAD_ON_BRANCH: release/26.08
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
         RATTLER_BUILD_COLOR: always
         RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
@@ -175,7 +175,7 @@ jobs:
         CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         CONFIG: ${{ matrix.CONFIG }}
         MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
-        UPLOAD_ON_BRANCH: main
+        UPLOAD_ON_BRANCH: release/26.08
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
         RATTLER_BUILD_COLOR: always
         RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'
@@ -211,7 +211,7 @@ jobs:
         CONFIG: ${{ matrix.CONFIG }}
         MINIFORGE_HOME: ${{ matrix.tools_install_dir }}
         PYTHONUNBUFFERED: 1
-        UPLOAD_ON_BRANCH: main
+        UPLOAD_ON_BRANCH: release/26.08
         UPLOAD_PACKAGES: ${{ matrix.UPLOAD_PACKAGES }}
         RATTLER_BUILD_COLOR: always
         RATTLER_BUILD_ENABLE_GITHUB_INTEGRATION: 'true'

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -85,7 +85,7 @@ call :end_group
 :: Prepare some environment variables for the upload step
 if /i "%CI%" == "github_actions" (
     set "FEEDSTOCK_NAME=%GITHUB_REPOSITORY:*/=%"
-    set "GIT_BRANCH=%GITHUB_REF:refs/heads/=%"
+    set "GIT_BRANCH=%GITHUB_REF_NAME%"
     if /i "%GITHUB_EVENT_NAME%" == "pull_request" (
         set "IS_PR_BUILD=True"
     ) else (

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -103,7 +103,7 @@ if /i "%CI%" == "azure" (
     )
     set "TEMP=%UPLOAD_TEMP%"
 )
-set "UPLOAD_ON_BRANCH=main"
+set "UPLOAD_ON_BRANCH=release/26.08"
 :: Note, this needs GIT_BRANCH too
 
 :: Validate

--- a/README.md
+++ b/README.md
@@ -57,31 +57,73 @@ conda config --add channels rapidsai-nightly
 conda config --set channel_priority strict
 ```
 
-Once the `rapidsai-nightly` channel has been enabled, `libxgboost, py-xgboost, r-xgboost, xgboost` can be installed with `conda`:
+How to use
+----------
+
+<details>
+<summary>With conda</summary>
 
 ```
 conda install libxgboost py-xgboost r-xgboost xgboost
 ```
 
-or with `mamba`:
+</details>
+
+<details>
+<summary>With mamba</summary>
 
 ```
 mamba install libxgboost py-xgboost r-xgboost xgboost
 ```
 
-It is possible to list all of the versions of `libxgboost` available on your platform with `conda`:
+</details>
+
+<details>
+<summary>With pixi</summary>
+
+```
+# for adding to your local project
+pixi add libxgboost py-xgboost r-xgboost xgboost
+# for installing globally
+pixi global install libxgboost py-xgboost r-xgboost xgboost
+```
+
+</details>
+
+Search package versions
+-----------------------
+
+It is possible to list all of the versions of `libxgboost` available on your platform:
+
+<details>
+<summary>With conda</summary>
 
 ```
 conda search libxgboost --channel rapidsai-nightly
 ```
 
-or with `mamba`:
+</details>
+
+<details>
+<summary>With mamba</summary>
 
 ```
 mamba search libxgboost --channel rapidsai-nightly
 ```
 
-Alternatively, `mamba repoquery` may provide more information:
+</details>
+
+<details>
+<summary>With pixi</summary>
+
+```
+pixi search libxgboost --channel rapidsai-nightly
+```
+
+</details>
+
+<details>
+<summary>With mamba repoquery, which may provide more information</summary>
 
 ```
 # Search all versions available on your platform:
@@ -93,6 +135,8 @@ mamba repoquery whoneeds libxgboost --channel rapidsai-nightly
 # List dependencies of `libxgboost`:
 mamba repoquery depends libxgboost --channel rapidsai-nightly
 ```
+
+</details>
 
 
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -18,7 +18,7 @@ provider:
   osx: github_actions
   win: github_actions
 test: native
-upload_on_branch: main
+upload_on_branch: release/26.08
 workflow_settings:
   free_disk_space:
     - platform: [linux_64, linux_aarch64]


### PR DESCRIPTION
This reconfigures uploads from the `main` branch to the `release/26.08` branch so packages can be built and uploaded.

In the past, this would not work correctly as there was not a simple method to get the branch name associated with the CI run via an environment variable name without workarounds (like `basename $GITHUB_REF`), which would mishandle `/` characters in the branch name. As a result this didn't work with our `release/YY.MM` convention. This is documented in PR: https://github.com/rapidsai/xgboost-feedstock/pull/125

To resolve this we simply would drop the `upload_on_branch` constraint, which effectively allows uploads from any branch on the repo (especially if included in `main`). This is not ideal either, but there was not a good alternative. However good GitHub hygiene (like using a fork for changes) and limiting this workaround to other branches (not `main`) kept this manageable. How this was done is shown in PR: https://github.com/rapidsai/xgboost-feedstock/pull/126

Thankfully GitHub has since added `GITHUB_REF_NAME`, which simply includes the branch name without other content for `push` events (and the PR info for `pull_request` events). This allows us to get the relevant information when checking whether to upload without workarounds like before thus ensuring we can properly constrain when uploads occur.

Have applied changes to this effect here to ensure uploads are limited to `release/26.08`.

Edit - These changes are being upstreamed to conda-smithy with PR: https://github.com/conda-forge/conda-smithy/pull/2632