### PR TITLE
Reset Python minimum to 3.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "3.3.0" %}
 {% set build_number = 5 %}
-{% set python_min = "3.12" %}
+{% set python_min = "3.11" %}
 {% set posix = 'm2-' if win else '' %}
 
 {% set string_prefix = "rapidsai" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.3.0" %}
-{% set build_number = 5 %}
+{% set build_number = 6 %}
 {% set python_min = "3.11" %}
 {% set posix = 'm2-' if win else '' %}
 


### PR DESCRIPTION
Follow up to PR: https://github.com/rapidsai/xgboost-feedstock/pull/147
Apply PR to `main`: https://github.com/rapidsai/xgboost-feedstock/pull/148

In order for packages to be installable on the oldest Python version supported `python_min` must be set to match. This was missed before, but is now being fixed in this PR.