### PR TITLE
Add deprecation warning for rapids-xgboost

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.3.0" %}
-{% set build_number = 5 %}
+{% set build_number = 6 %}
 {% set python_min = "3.11" %}
 {% set posix = 'm2-' if win else '' %}
 
@@ -19,6 +19,7 @@ source:
     - patches/0003-Mark-wheels-as-any-platform-compatible.patch
     - patches/0004-Include-cuda-std-type_traits-in-histogram.cu.patch
     - patches/0005-Add-back-support-for-Python-3.11.patch
+    - patches/0006-Add-deprecation-warning.patch
 
 build:
   number: {{ build_number }}

--- a/recipe/patches/0006-Add-deprecation-warning.patch
+++ b/recipe/patches/0006-Add-deprecation-warning.patch
@@ -18,7 +18,7 @@ index 5162d952d..e3d855322 100644
 +    warnings.warn(
 +        "`rapids-xgboost` will no longer be published in the `rapidsai` Conda channel "
 +        "with the 26.10 release. Please use the `xgboost` package from `conda-forge`, "
-+        "or the `xgboost` wheels from the Python Package Index (PyPI).",
++        "or the `xgboost` wheel from the Python Package Index (PyPI).",
 +        FutureWarning,
 +    )
 +

--- a/recipe/patches/0006-Add-deprecation-warning.patch
+++ b/recipe/patches/0006-Add-deprecation-warning.patch
@@ -1,24 +1,25 @@
-From e703928db792e55555d0cc7ab1740953175be4ee Mon Sep 17 00:00:00 2001
+From 8f80164b4aaead0deeb6014bd3428700657aac67 Mon Sep 17 00:00:00 2001
 From: Hyunsu Cho <phcho@nvidia.com>
 Date: Wed, 29 Jul 2026 12:55:44 -0700
 Subject: [PATCH] Add deprecation warning
 
 ---
- python-package/xgboost/_c_api.py | 7 +++++++
- 1 file changed, 7 insertions(+)
+ python-package/xgboost/_c_api.py | 8 ++++++++
+ 1 file changed, 8 insertions(+)
 
 diff --git a/python-package/xgboost/_c_api.py b/python-package/xgboost/_c_api.py
-index 5162d952d..e3d855322 100644
+index 5162d952d..5932217db 100644
 --- a/python-package/xgboost/_c_api.py
 +++ b/python-package/xgboost/_c_api.py
-@@ -177,6 +177,13 @@ Likely cause:
+@@ -177,6 +177,14 @@ Likely cause:
          )
          raise ValueError(msg)
  
 +    warnings.warn(
 +        "`rapids-xgboost` will no longer be published in the `rapidsai` Conda channel "
 +        "with the 26.10 release. Please use the `xgboost` package from `conda-forge`, "
-+        "or the `xgboost` wheel from the Python Package Index (PyPI).",
++        "or the `xgboost` wheel from the Python Package Index (PyPI). "
++        "Consult https://docs.rapids.ai/notices/rsn0062/ for more details.",
 +        FutureWarning,
 +    )
 +

--- a/recipe/patches/0006-Add-deprecation-warning.patch
+++ b/recipe/patches/0006-Add-deprecation-warning.patch
@@ -16,7 +16,7 @@ index 5162d952d..5932217db 100644
          raise ValueError(msg)
  
 +    warnings.warn(
-+        "`rapids-xgboost` will no longer be published in the `rapidsai` Conda channel "
++        "`rapids-xgboost` will no longer be published in the `rapidsai` conda channel "
 +        "with the 26.10 release. Please use the `xgboost` package from `conda-forge`, "
 +        "or the `xgboost` wheel from the Python Package Index (PyPI). "
 +        "Consult https://docs.rapids.ai/notices/rsn0062/ for more details.",

--- a/recipe/patches/0006-Add-deprecation-warning.patch
+++ b/recipe/patches/0006-Add-deprecation-warning.patch
@@ -1,0 +1,30 @@
+From e703928db792e55555d0cc7ab1740953175be4ee Mon Sep 17 00:00:00 2001
+From: Hyunsu Cho <phcho@nvidia.com>
+Date: Wed, 29 Jul 2026 12:55:44 -0700
+Subject: [PATCH] Add deprecation warning
+
+---
+ python-package/xgboost/_c_api.py | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/python-package/xgboost/_c_api.py b/python-package/xgboost/_c_api.py
+index 5162d952d..e3d855322 100644
+--- a/python-package/xgboost/_c_api.py
++++ b/python-package/xgboost/_c_api.py
+@@ -177,6 +177,13 @@ Likely cause:
+         )
+         raise ValueError(msg)
+ 
++    warnings.warn(
++        "`rapids-xgboost` will no longer be published in the `rapidsai` Conda channel "
++        "with the 26.10 release. Please use the `xgboost` package from `conda-forge`, "
++        "or the `xgboost` wheels from the Python Package Index (PyPI).",
++        FutureWarning,
++    )
++
+     return lib
+ 
+ 
+-- 
+2.54.0
+


### PR DESCRIPTION
Part of issue: https://github.com/rapidsai/build-planning/issues/312

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

The deprecation warning will be displayed at the import time.

```
In [1]: import xgboost
/home/phcho/miniforge3/lib/python3.13/site-packages/xgboost/_c_api.py:180:
FutureWarning: `rapids-xgboost` will no longer be published in the `rapidsai` Conda channel with the 26.10 release.
Please use the `xgboost` package from `conda-forge`, or the `xgboost` wheels from the Python Package Index (PyPI).
```