### PR TITLE
Rebuild RAPIDS XGBoost 26.08 w/CCCL 3.4.3-rc0 & Deprecate RAPIDS XGBoost in 26.08

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -97,6 +97,7 @@ jobs:
           - CONFIG: win_64_cuda_compiler_version12.9
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
+            build_platform: win-64
             build_workspace_dir: D:\\bld\\
             docker_run_args: 
             free_disk_space: skip
@@ -108,6 +109,7 @@ jobs:
           - CONFIG: win_64_cuda_compiler_version13.3
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
+            build_platform: win-64
             build_workspace_dir: D:\\bld\\
             docker_run_args: 
             free_disk_space: skip
@@ -119,7 +121,7 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Manage disk space
       env:
@@ -206,6 +208,7 @@ jobs:
         set "sha=%GITHUB_SHA%"
         call ".scripts\run_win_build.bat"
       env:
+        BUILD_PLATFORM: ${{ matrix.build_platform }}
         CI: github_actions
         CONDA_BLD_PATH: ${{ matrix.build_workspace_dir }}
         CONFIG: ${{ matrix.CONFIG }}

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -66,7 +66,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     #   - --output-id vs. --output-name
     #   - --clobber-file vs. none
     #   - none vs. --target-platform
-    conda debug \
+    CONDA_SUBDIR="${BUILD_PLATFORM}" conda debug \
         "${RECIPE_ROOT}" \
         -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \
@@ -82,7 +82,7 @@ else
     #   - --clobber-file vs. none
     #   - none vs. --target-platform
     #   - --extra-meta a=b c=d vs. --extra-meta a=b --extra-meta c=d
-    conda-build \
+    CONDA_SUBDIR="${BUILD_PLATFORM}" conda-build \
         "${RECIPE_ROOT}" \
         -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -100,7 +100,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
     fi
-    conda debug ./recipe -m ./.ci_support/${CONFIG}.yaml \
+    CONDA_SUBDIR="${BUILD_PLATFORM}" conda debug ./recipe -m ./.ci_support/${CONFIG}.yaml \
         ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
 
@@ -112,7 +112,7 @@ else
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
     fi
 
-    conda-build ./recipe -m ./.ci_support/${CONFIG}.yaml \
+    CONDA_SUBDIR="${BUILD_PLATFORM}" conda-build ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
         --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -74,8 +74,12 @@ call :end_group
 
 :: Build the recipe
 echo Building recipe
+set "_OLD_CONDA_SUBDIR=%CONDA_SUBDIR%"
+set "CONDA_SUBDIR=%BUILD_PLATFORM%"
 conda-build.exe "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 if !errorlevel! neq 0 exit /b !errorlevel!
+set "_OLD_CONDA_SUBDIR="
+set "CONDA_SUBDIR=%_OLD_CONDA_SUBDIR%"
 
 call :start_group "Inspecting artifacts"
 :: inspect_artifacts was only added in conda-forge-ci-setup 4.9.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.3.0" %}
-{% set build_number = 6 %}
+{% set build_number = 7 %}
 {% set python_min = "3.11" %}
 {% set posix = 'm2-' if win else '' %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -231,6 +231,8 @@ about:
     environment (Hadoop, SGE, MPI) and can solve problems beyond billions of examples.
   doc_url: https://xgboost.readthedocs.io/
   dev_url: https://github.com/dmlc/xgboost/
+  prelink_message:
+    - prelink_rapids_xgboost_deprecation.txt
 
 extra:
   feedstock-name: xgboost

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.3.0" %}
-{% set build_number = 5 %}
+{% set build_number = 6 %}
 {% set python_min = "3.11" %}
 {% set posix = 'm2-' if win else '' %}
 

--- a/recipe/prelink_rapids_xgboost_deprecation.txt
+++ b/recipe/prelink_rapids_xgboost_deprecation.txt
@@ -1,0 +1,10 @@
+RAPIDS XGBoost is deprecated
+
+As of RAPIDS 26.08, RAPIDS XGBoost is deprecated. Going forward XGBoost
+packages will be available via conda-forge. These can be installed like so:
+
+conda install -c conda-forge cuda-version=<CUDA ver> xgboost
+
+More details can be found on this page:
+
+https://github.com/conda-forge/xgboost-feedstock/tree/main#installing-xgboost

--- a/recipe/prelink_rapids_xgboost_deprecation.txt
+++ b/recipe/prelink_rapids_xgboost_deprecation.txt
@@ -1,7 +1,11 @@
-RAPIDS XGBoost is deprecated
+RAPIDS XGBoost is Deprecated
 
-As of RAPIDS 26.08, RAPIDS XGBoost is deprecated. Going forward XGBoost
-packages will be available via conda-forge. These can be installed like so:
+As of RAPIDS 26.08, RAPIDS XGBoost is deprecated. More details in RSN 62:
+
+https://docs.rapids.ai/notices/rsn0062/
+
+Going forward XGBoost packages will be available via conda-forge. These can be
+installed like so:
 
 conda install -c conda-forge cuda-version=<CUDA version> xgboost
 

--- a/recipe/prelink_rapids_xgboost_deprecation.txt
+++ b/recipe/prelink_rapids_xgboost_deprecation.txt
@@ -3,8 +3,16 @@ RAPIDS XGBoost is deprecated
 As of RAPIDS 26.08, RAPIDS XGBoost is deprecated. Going forward XGBoost
 packages will be available via conda-forge. These can be installed like so:
 
-conda install -c conda-forge cuda-version=<CUDA ver> xgboost
+conda install -c conda-forge cuda-version=<CUDA version> xgboost
 
-More details can be found on this page:
+More details can be found on the conda-forge XGBoost README:
 
 https://github.com/conda-forge/xgboost-feedstock/tree/main#installing-xgboost
+
+Note that the `__cuda` virtual package must be present either by having an
+NVIDIA GPU with the driver installed or setting the environment variable
+`CONDA_OVERRIDE_CUDA` to the intended CUDA version.
+
+More details in the Conda virtual package docs:
+
+https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-virtual.html#managing-virtual-packages


### PR DESCRIPTION
Part of issue: https://github.com/rapidsai/build-planning/issues/312

Rebuild XGBoost using RMM 26.08 with CCCL 3.4.3-rc0. Also deprecate RAPIDS XGBoost packages in 26.08.

Ref:
* https://github.com/rapidsai/rapids-cmake/pull/1067